### PR TITLE
Updating FB audience SDK

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,7 @@
           
         <framework src="com.android.support:support-v4:+" />
         <framework src="com.google.android.gms:play-services-ads:+"/>
-        <framework src="com.facebook.android:audience-network-sdk:4.+"/>
+        <framework src="com.facebook.android:audience-network-sdk:4.21.+"/>
      </platform>
      
      <!-- ios -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,9 +13,11 @@
     <repo>https://github.com/floatinghotpot/cordova-plugin-facebookads.git</repo>
     <issue>https://github.com/floatinghotpot/cordova-plugin-facebookads/issues</issue>
 
-	<engines>
-	    <engine name="cordova" version=">=3.0" />
-	</engines>
+    <engines>
+        <engine name="cordova" version=">=6.4.0"/>
+        <engine name="cordova-android" version=">=6.0.0"/>
+        <engine name="cordova-ios" version=">=4.3.0"/>
+    </engines>
 
     <js-module src="www/FacebookAds.js" name="FacebookAds">
         <clobbers target="window.FacebookAds" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,6 @@
     </js-module>
 
 	<dependency id="cordova-plugin-extension"/>
-	<dependency id="cordova-facebook-audnet-sdk"/>
 
     <!-- android -->
     <platform name="android">
@@ -43,6 +42,8 @@
         </config-file>
           
         <framework src="com.android.support:support-v4:+" />
+        <framework src="com.google.android.gms:play-services-ads:+"/>
+        <framework src="com.facebook.android:audience-network-sdk:4.+"/>
      </platform>
      
      <!-- ios -->
@@ -64,6 +65,7 @@
         <framework src="QuartzCore.framework"/>
         <framework src="OpenGLES.framework"/>
         <framework src="Security.framework"/>
+        <framework src="FBAudienceNetwork" type="podspec" spec="~> 4.21.0"/>
     </platform>
 
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -65,7 +65,7 @@
         <framework src="QuartzCore.framework"/>
         <framework src="OpenGLES.framework"/>
         <framework src="Security.framework"/>
-        <framework src="FBAudienceNetwork" type="podspec" spec="~> 4.21.0"/>
+        <framework src="FBAudienceNetwork" type="podspec" spec="< 4.21.0"/>
     </platform>
 
 </plugin>


### PR DESCRIPTION
Fixes https://github.com/floatinghotpot/cordova-plugin-facebookads/issues/52

Few things to note/discuss:

* `com.facebook.android:audience-network-sdk:4.+` depends on `com.google.android.gms:play-services-ads:8.4.0`, which is a problem, if using any other cordova plugins that depend on a newer major version of play-services (push notifications, google analytics, etc) so I've added an override to fetch the newest version

* Tested on Android & iOS - works now